### PR TITLE
feat: pinning version of openssh and sshpass dependencies

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -97,7 +97,7 @@ make clean
 
 ```bash
 # Push your code up to your fork
-git push fork master
+git push fork main
 ```
 
 * Open a pull request. Thank you for your contribution!

--- a/.github/README.md
+++ b/.github/README.md
@@ -3,7 +3,7 @@
 [![license](https://img.shields.io/crates/l/gl.svg)](../LICENSE)
 [![GoDoc](https://godoc.org/github.com/go-vela/vela-openssh?status.svg)](https://godoc.org/github.com/go-vela/vela-openssh)
 [![Go Report Card](https://goreportcard.com/badge/go-vela/vela-openssh)](https://goreportcard.com/report/go-vela/vela-openssh)
-[![codecov](https://codecov.io/gh/go-vela/vela-openssh/branch/master/graph/badge.svg)](https://codecov.io/gh/go-vela/vela-openssh)
+[![codecov](https://codecov.io/gh/go-vela/vela-openssh/branch/main/graph/badge.svg)](https://codecov.io/gh/go-vela/vela-openssh)
 
 A set of Vela plugins designed to make common SSH and SCP actions easy to do within the Vela CI environment.
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ master ]
+    branches: [ main ]
   schedule:
     - cron: '30 21 * * 0'
 

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -32,6 +32,11 @@ jobs:
       run: |
         make build-static-ci
 
+    - name: grab dependency versions from makefile
+      run: |
+        grep "^OPENSSH.*=" Makefile >> $GITHUB_ENV
+        grep "^SSHPASS_VERSION.*=" Makefile >> $GITHUB_ENV
+
     - name: publish scp
       uses: elgohr/Publish-Docker-Github-Action@master
       with:
@@ -41,6 +46,7 @@ jobs:
         dockerfile: Dockerfile.scp
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
+        buildargs: OPENSSH_VERSION,SSHPASS_VERSION
 
     - name: publish ssh
       uses: elgohr/Publish-Docker-Github-Action@master
@@ -51,3 +57,4 @@ jobs:
         dockerfile: Dockerfile.ssh
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
+        buildargs: OPENSSH_VERSION,SSHPASS_VERSION

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,10 +1,10 @@
 # name of the action
 name: publish
 
-# trigger on push events with branch master
+# trigger on push events with branch main
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
 
 # pipeline to execute
 jobs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,6 +26,11 @@ jobs:
       run: |
         make build-static-ci
 
+    - name: grab dependency versions from makefile
+      run: |
+        grep "^OPENSSH.*=" Makefile >> $GITHUB_ENV
+        grep "^SSHPASS_VERSION.*=" Makefile >> $GITHUB_ENV
+
     - name: publish scp
       uses: elgohr/Publish-Docker-Github-Action@master
       with:
@@ -34,6 +39,7 @@ jobs:
         dockerfile: Dockerfile.scp
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
+        buildargs: OPENSSH_VERSION,SSHPASS_VERSION
 
     - name: publish ssh
       uses: elgohr/Publish-Docker-Github-Action@master
@@ -43,3 +49,4 @@ jobs:
         dockerfile: Dockerfile.ssh
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
+        buildargs: OPENSSH_VERSION,SSHPASS_VERSION

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,11 +41,8 @@ jobs:
     - name: integration test with fake server
       run: make docker-build && make docker-test
 
-  publish-test:
+  gha-publish-test:
     runs-on: ubuntu-latest
-    needs:
-    - unit-test
-    - integration-test
     container:
       image: golang:1.17
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,3 +40,47 @@ jobs:
 
     - name: integration test with fake server
       run: make docker-build && make docker-test
+
+  publish-test:
+    runs-on: ubuntu-latest
+    needs:
+    - unit-test
+    - integration-test
+    container:
+      image: golang:1.17
+    steps:
+    - name: clone
+      uses: actions/checkout@v2
+      with:
+        # ensures we fetch tag history for the repository
+        fetch-depth: 0
+
+    - name: build
+      env:
+        GOOS: linux
+        CGO_ENABLED: '0'
+      run: |
+        make build-static-ci
+
+    - name: grab dependency versions from makefile
+      run: |
+        grep "^OPENSSH.*=" Makefile >> $GITHUB_ENV
+        grep "^SSHPASS_VERSION.*=" Makefile >> $GITHUB_ENV
+
+    - name: publish scp
+      uses: elgohr/Publish-Docker-Github-Action@master
+      with:
+        name: target/vela-scp
+        cache: true
+        dockerfile: Dockerfile.scp
+        no_push: true
+        buildargs: OPENSSH_VERSION,SSHPASS_VERSION
+
+    - name: publish ssh
+      uses: elgohr/Publish-Docker-Github-Action@master
+      with:
+        name: target/vela-ssh
+        cache: true
+        dockerfile: Dockerfile.ssh
+        no_push: true
+        buildargs: OPENSSH_VERSION,SSHPASS_VERSION

--- a/Dockerfile.scp
+++ b/Dockerfile.scp
@@ -8,7 +8,16 @@
 
 FROM alpine:latest
 
-RUN apk add --update --no-cache ca-certificates openssh sshpass
+# Build args to be used from the Makefile
+ARG OPENSSH_VERSION
+ARG SSHPASS_VERSION
+
+# Set environmental variables to the build args so the container
+# keeps the history of what it was built with if users want to check.
+ENV OPENSSH_VERSION=$OPENSSH_VERSION
+ENV SSHPASS_VERSION=$SSHPASS_VERSION
+
+RUN apk add --update --no-cache ca-certificates openssh=${OPENSSH_VERSION} sshpass=${SSHPASS_VERSION}
 
 COPY release/vela-scp /bin/vela-scp
 

--- a/Dockerfile.ssh
+++ b/Dockerfile.ssh
@@ -8,7 +8,16 @@
 
 FROM alpine:latest
 
-RUN apk add --update --no-cache ca-certificates openssh sshpass
+# Build args to be used from the Makefile
+ARG OPENSSH_VERSION
+ARG SSHPASS_VERSION
+
+# Set environmental variables to the build args so the container
+# keeps the history of what it was built with if users want to check.
+ENV OPENSSH_VERSION=$OPENSSH_VERSION
+ENV SSHPASS_VERSION=$SSHPASS_VERSION
+
+RUN apk add --update --no-cache ca-certificates openssh=${OPENSSH_VERSION} sshpass=${SSHPASS_VERSION}
 
 COPY release/vela-ssh /bin/vela-ssh
 

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,13 @@
 # capture the current date we build the application from
 BUILD_DATE = $(shell date +%Y-%m-%dT%H:%M:%SZ)
 
+# Versions installed for OpenSSH and SSHPass binaries.
+# This is the ONLY place these hardcoded versions are set.
+# They're used in the Dockerfile the GitHub Actions workflow,
+# the integration tests, and the static build flags for Go.
+OPENSSH_VERSION = 8.8_p1-r1
+SSHPASS_VERSION=1.09-r0
+
 # check if a git commit sha is already set
 ifndef GITHUB_SHA
 	# capture the current git commit sha we build the application from
@@ -27,7 +34,7 @@ endif
 # The reference here to Kaniko is so that this repo doesn't need to duplicate
 # the version.go file across multiple plugin repositories. Ideally that file would
 # migrate into its own repository at some point so that it can be widely used.
-LD_FLAGS = -X github.com/go-vela/vela-kaniko/version.Commit=${GITHUB_SHA} -X github.com/go-vela/vela-kaniko/version.Date=${BUILD_DATE} -X github.com/go-vela/vela-kaniko/version.Go=${GOLANG_VERSION} -X github.com/go-vela/vela-kaniko/version.Tag=${GITHUB_TAG}
+LD_FLAGS = -X github.com/go-vela/vela-openssh/internal/openssh.OpenSSHVersion=${OPENSSH_VERSION} -X github.com/go-vela/vela-openssh/internal/openssh.SSHPassVersion=${SSHPASS_VERSION} -X github.com/go-vela/vela-kaniko/version.Commit=${GITHUB_SHA} -X github.com/go-vela/vela-kaniko/version.Date=${BUILD_DATE} -X github.com/go-vela/vela-kaniko/version.Go=${GOLANG_VERSION} -X github.com/go-vela/vela-kaniko/version.Tag=${GITHUB_TAG}
 
 # The `clean` target is intended to clean the workspace
 # and prepare the local changes for submission.
@@ -237,8 +244,8 @@ bump-deps-full: check
 docker-build:
 	@echo
 	@echo "### Building vela-scp:local image"
-	@docker build -f Dockerfile.scp --no-cache -t vela-scp:local .
-	@docker build -f Dockerfile.ssh --no-cache -t vela-ssh:local .
+	@docker build -f Dockerfile.scp --no-cache --build-arg OPENSSH_VERSION=${OPENSSH_VERSION} --build-arg SSHPASS_VERSION=${SSHPASS_VERSION} -t vela-scp:local .
+	@docker build -f Dockerfile.ssh --no-cache --build-arg OPENSSH_VERSION=${OPENSSH_VERSION} --build-arg SSHPASS_VERSION=${SSHPASS_VERSION} -t vela-ssh:local .
 
 # The `docker-test` target is intended to execute
 # the Docker image for the plugin with test variables

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@ BUILD_DATE = $(shell date +%Y-%m-%dT%H:%M:%SZ)
 # This is the ONLY place these hardcoded versions are set.
 # They're used in the Dockerfile the GitHub Actions workflow,
 # the integration tests, and the static build flags for Go.
-OPENSSH_VERSION = 8.8_p1-r1
+# Note: No space between the equals and the value else issues arise.
+OPENSSH_VERSION=8.8_p1-r1
 SSHPASS_VERSION=1.09-r0
 
 # check if a git commit sha is already set

--- a/cmd/vela-scp/main.go
+++ b/cmd/vela-scp/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/sirupsen/logrus"
@@ -22,8 +23,11 @@ func main() {
 				Email: "vela@target.com",
 			},
 		},
-		Action:  run,
-		Version: openssh.PluginVersion.Semantic(),
+		Action: run,
+		// The version field looks gross but in practice is really only seen and used in integration tests
+		// or when a plugin is misconfigured. We should log the version information of dependent binaries
+		// to assist with debugging why a plugin might be failing to operate in a way users expect.
+		Version: fmt.Sprintf("Plugin: %s - OpenSSH: %s - SSHPass: %s", openssh.PluginVersion.Semantic(), openssh.OpenSSHVersion, openssh.SSHPassVersion),
 		Flags: []cli.Flag{
 			&cli.StringSliceFlag{
 				Name:     "source",
@@ -103,11 +107,13 @@ func run(c *cli.Context) error {
 	}
 
 	logrus.WithFields(logrus.Fields{
-		"code":     "https://github.com/go-vela/vela-openssh",
-		"docs":     "https://go-vela.github.io/docs/plugins/registry/scp",
-		"registry": "https://hub.docker.com/r/target/vela-scp",
-		"version":  openssh.PluginVersion.Semantic(),
-		"commit":   openssh.PluginVersion.Metadata.GitCommit,
+		"code":            "https://github.com/go-vela/vela-openssh",
+		"docs":            "https://go-vela.github.io/docs/plugins/registry/scp",
+		"registry":        "https://hub.docker.com/r/target/vela-scp",
+		"commit":          openssh.PluginVersion.Metadata.GitCommit,
+		"version-plugin":  openssh.PluginVersion.Semantic(),
+		"version-openssh": openssh.OpenSSHVersion,
+		"version-sshpass": openssh.SSHPassVersion,
 	}).Info("Vela SCP Plugin")
 
 	bp := binarywrapper.Plugin{

--- a/cmd/vela-ssh/main.go
+++ b/cmd/vela-ssh/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/sirupsen/logrus"
@@ -22,8 +23,11 @@ func main() {
 				Email: "vela@target.com",
 			},
 		},
-		Action:  run,
-		Version: openssh.PluginVersion.Semantic(),
+		Action: run,
+		// The version field looks gross but in practice is really only seen and used in integration tests
+		// or when a plugin is misconfigured. We should log the version information of dependent binaries
+		// to assist with debugging why a plugin might be failing to operate in a way users expect.
+		Version: fmt.Sprintf("Plugin: %s - OpenSSH: %s - SSHPass: %s", openssh.PluginVersion.Semantic(), openssh.OpenSSHVersion, openssh.SSHPassVersion),
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:     "destination",
@@ -103,11 +107,13 @@ func run(c *cli.Context) error {
 	}
 
 	logrus.WithFields(logrus.Fields{
-		"code":     "https://github.com/go-vela/vela-openssh",
-		"docs":     "https://go-vela.github.io/docs/plugins/registry/ssh",
-		"registry": "https://hub.docker.com/r/target/vela-ssh",
-		"version":  openssh.PluginVersion.Semantic(),
-		"commit":   openssh.PluginVersion.Metadata.GitCommit,
+		"code":            "https://github.com/go-vela/vela-openssh",
+		"docs":            "https://go-vela.github.io/docs/plugins/registry/ssh",
+		"registry":        "https://hub.docker.com/r/target/vela-ssh",
+		"commit":          openssh.PluginVersion.Metadata.GitCommit,
+		"version-plugin":  openssh.PluginVersion.Semantic(),
+		"version-openssh": openssh.OpenSSHVersion,
+		"version-sshpass": openssh.SSHPassVersion,
 	}).Info("Vela SSH Plugin")
 
 	bp := binarywrapper.Plugin{

--- a/internal/openssh/openssh.go
+++ b/internal/openssh/openssh.go
@@ -14,6 +14,12 @@ import (
 	"github.com/spf13/afero"
 )
 
+// These are build time constants for use in logging which binaries a plugin happens to be using.
+var (
+	OpenSSHVersion = "unknown"
+	SSHPassVersion = "unknown"
+)
+
 var (
 	// PluginVersion provides a common place to pull the plugin configuration from.
 	PluginVersion = version.New()

--- a/test/docker-compose-scp.yml
+++ b/test/docker-compose-scp.yml
@@ -87,3 +87,12 @@ services:
     image: vela-scp:local
     entrypoint: which
     command: scp
+
+  ensure-version-info-set:
+    depends_on:
+      - fake-remote-server
+    image: vela-scp:local
+    volumes:
+      - ./ensure-version-info-set.sh:/ensure-version-info-set.sh
+    entrypoint: sh
+    command: /ensure-version-info-set.sh scp

--- a/test/docker-compose-ssh.yml
+++ b/test/docker-compose-ssh.yml
@@ -87,3 +87,12 @@ services:
     image: vela-ssh:local
     entrypoint: ssh
     command: -V
+
+  ensure-version-info-set:
+    depends_on:
+      - fake-remote-server
+    image: vela-ssh:local
+    volumes:
+      - ./ensure-version-info-set.sh:/ensure-version-info-set.sh
+    entrypoint: sh
+    command: /ensure-version-info-set.sh ssh

--- a/test/ensure-version-info-set.sh
+++ b/test/ensure-version-info-set.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -e
+
+BINARY="$1"
+
+if [ -z "${OPENSSH_VERSION}" ]; then
+  printf "OPENSSH_VERSION missing\n"
+  exit 1
+fi
+
+if [ -z "${SSHPASS_VERSION}" ]; then
+  printf "SSHPASS_VERSION missing\n"
+  exit 2
+fi
+
+if "/bin/vela-$BINARY" -v | grep unknown; then
+  printf "Version information isn't set\n"
+  exit 3
+fi

--- a/test/integration-tests.sh
+++ b/test/integration-tests.sh
@@ -11,6 +11,7 @@ SCP_TESTS=(
   passphrase-auth
   additional-secrets-in-params
   override-plugin
+  ensure-version-info-set
 )
 
 SSH_TESTS=(
@@ -20,6 +21,7 @@ SSH_TESTS=(
   passphrase-auth
   additional-secrets-in-params
   override-plugin
+  ensure-version-info-set
 )
 
 # Make sure we move into the folder where the integration tests


### PR DESCRIPTION
This includes a couple of changes which allows for pinning the version of the OpenSSH and SSHPass binaries. It also includes this information in the help and version information for each plugin. It includes integration tests to make sure versions aren't unknown and that they're set in the built docker containers as well.

There are probably things to be cleaned up or pulled into common functionality at some point, but for now this should allow for pinning the version information in the Makefile only and then all the rest should be pulled in automatically.