### PR TITLE
feat: annotate versions for renovate management

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,5 +2,16 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>go-vela/renovate-config"
+  ],
+  "regexManagers": [
+    {
+      "fileMatch": [
+        "^Makefile$"
+      ],
+      "matchStrings": [
+        "#\\s*renovate:\\s*datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s.*?_VERSION=(?<currentValue>.*)"
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
+    }
   ]
 }

--- a/Dockerfile.scp
+++ b/Dockerfile.scp
@@ -6,7 +6,7 @@
 ##     docker build --no-cache -t vela-scp:local .     ##
 ###############################################################
 
-FROM alpine:latest
+FROM alpine:3.15@sha256:21a3deaa0d32a8057914f36584b5288d2e5ecc984380bc0118285c70fa8c9300
 
 # Build args to be used from the Makefile
 ARG OPENSSH_VERSION

--- a/Dockerfile.ssh
+++ b/Dockerfile.ssh
@@ -6,7 +6,7 @@
 ##     docker build --no-cache -t vela-ssh:local .     ##
 ###############################################################
 
-FROM alpine:latest
+FROM alpine:3.15@sha256:21a3deaa0d32a8057914f36584b5288d2e5ecc984380bc0118285c70fa8c9300
 
 # Build args to be used from the Makefile
 ARG OPENSSH_VERSION

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,9 @@ BUILD_DATE = $(shell date +%Y-%m-%dT%H:%M:%SZ)
 # They're used in the Dockerfile the GitHub Actions workflow,
 # the integration tests, and the static build flags for Go.
 # Note: No space between the equals and the value else issues arise.
+# renovate: datasource=repology depName=alpine_3_15/openssh versioning=loose
 OPENSSH_VERSION=8.8_p1-r1
+# renovate: datasource=repology depName=alpine_3_15/sshpass versioning=loose
 SSHPASS_VERSION=1.09-r0
 
 # check if a git commit sha is already set


### PR DESCRIPTION
This aims to extend Renovate so that it can manage the binary dependencies from the Makefile along with pinning a particular version of the alpine image in the Dockerfiles so that it can be managed as well.

Here is a link to a Regex101 share of the regex group matching with the makefile. Note that the regex101 has converted all `\\s` into `\s` just because of the JSON interpolation stuffs.
https://regex101.com/r/hHiMta/1

This followed from the example in the Whitesource documentation that @wass3r pointed out in a previous PR: https://docs.renovatebot.com/modules/datasource/#repology-datasource