### PR TITLE
chore(ci): fix actions

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -38,7 +38,7 @@ jobs:
         grep "^SSHPASS_VERSION.*=" Makefile >> $GITHUB_ENV
 
     - name: publish scp
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v4
       with:
         name: target/vela-scp
         cache: true
@@ -49,7 +49,7 @@ jobs:
         buildargs: OPENSSH_VERSION,SSHPASS_VERSION
 
     - name: publish ssh
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v4
       with:
         name: target/vela-ssh
         cache: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
         grep "^SSHPASS_VERSION.*=" Makefile >> $GITHUB_ENV
 
     - name: publish scp
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v4
       with:
         name: target/vela-scp
         cache: true
@@ -42,7 +42,7 @@ jobs:
         buildargs: OPENSSH_VERSION,SSHPASS_VERSION
 
     - name: publish ssh
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v4
       with:
         name: target/vela-ssh
         cache: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,19 +71,21 @@ jobs:
         grep "^SSHPASS_VERSION.*=" Makefile >> $GITHUB_ENV
 
     - name: publish scp
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v4
       with:
         name: target/vela-scp
         cache: true
         dockerfile: Dockerfile.scp
         no_push: true
         buildargs: OPENSSH_VERSION,SSHPASS_VERSION
+        tags: "test"
 
     - name: publish ssh
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v4
       with:
         name: target/vela-ssh
         cache: true
         dockerfile: Dockerfile.ssh
         no_push: true
         buildargs: OPENSSH_VERSION,SSHPASS_VERSION
+        tags: "test"


### PR DESCRIPTION
attempt to fix the following:

1. update docker publish action per message
2. don't use branch name for tags, since it can have invalid characters

```
>> elgohr/Publish-Docker-Github-Action@master has been deprecated.
>> Please use elgohr/Publish-Docker-Github-Action@v4 for a blast in speed and security.
invalid argument "target/vela-scp:renovate-deps-(patch)" for "-t, --tag" flag: invalid reference format
```